### PR TITLE
[44] T-21c: Repo-Cleanup – Runbook, default-setup.md, stash

### DIFF
--- a/docs/runbooks/mcp/default-setup.md
+++ b/docs/runbooks/mcp/default-setup.md
@@ -1,7 +1,7 @@
 # Default-Setup für `gjo-mcp-servers`
 
 > Kanonische Referenz für den **aktuellen** lokalen Standardpfad.
-> Stand heute: Der Default ist **`doc_server` / `mcpdoc`**.
+> Stand heute: Der Default sind **`doc_server`** (8004) und **`web_search_server`** (8006).
 
 ---
 
@@ -18,12 +18,12 @@ Dieses Runbook beantwortet für den aktuellen Projektstand genau vier Fragen:
 
 ## Entscheidung
 
-Der aktuelle kanonische Default von `gjo-mcp-servers` ist:
+Der aktuelle kanonische Default von `gjo-mcp-servers` sind:
 
-- **Service:** `doc_server`
-- **Zweck:** `mcpdoc` / aktuelle Dokumentationsquellen
-- **Transportziel:** `http://localhost:8004/mcp`
-- **Kanonische Client-Konfiguration:** `.mcp.json` enthält aktuell nur `doc-server`
+- **Service:** `doc_server` + `web_search_server`
+- **Zweck:** aktuelle Dokumentationsquellen + generische Web-Suche
+- **Transportziele:** `http://localhost:8004/mcp` · `http://localhost:8006/mcp`
+- **Kanonische Client-Konfiguration:** `.mcp.json` enthält `doc-server` und `web-search-server`
 
 Nicht Teil des heutigen Default-Setups:
 
@@ -40,11 +40,11 @@ Diese Dienste bleiben vorhanden, sind aber aktuell **opt-in** über das Compose-
 
 Für den aktuellen Projektstand gelten bewusst diese Entscheidungen:
 
-1. `doc-server` bleibt in `docker-compose.override.yml`.
-2. Der lokale Standardbefehl bleibt trotzdem `docker compose up -d`, weil das Override lokal automatisch geladen wird.
-3. PostgreSQL ist für den heutigen `mcpdoc`-Default nicht nötig.
-4. Pflichtvariablen sind `PORT_DOC` und `LOG_LEVEL`.
-5. `TAVILY_API_KEY` ist nur für den Fallback `web_search_documentation` optional relevant.
+1. `doc-server` und `web-search-server` liegen in `docker-compose.override.yml`.
+2. Der lokale Standardbefehl bleibt `docker compose up -d`.
+3. PostgreSQL ist für den heutigen Default nicht nötig.
+4. Pflichtfelder: `PORT_DOC`, `PORT_WEB_SEARCH` und `LOG_LEVEL`.
+5. `TAVILY_API_KEY` ist für `web_search_documentation` und `web_search` erforderlich.
 6. Alle weiteren MCP-Server gehören aktuell nicht zum kanonischen Default.
 
 ---
@@ -71,9 +71,10 @@ Permanente Referenz für den Setup-Zustand:
 Die Datei `.mcp.json` im Repo-Root ist die aktuelle Quelle der Wahrheit für den
 MCP-Client-Default.
 
-Im heutigen Stand enthält sie bewusst nur:
+Im heutigen Stand enthält sie:
 
 - `doc-server` → `http://localhost:8004/mcp`
+- `web-search-server` → `http://localhost:8006/mcp`
 
 Nicht Teil der kanonischen Default-Konfiguration:
 
@@ -93,23 +94,22 @@ gehören aber aktuell **nicht** zum Standard.
 
 ```dotenv
 PORT_DOC=8004
+PORT_WEB_SEARCH=8006
 LOG_LEVEL=INFO
 ```
 
-### Optional für den Defaultpfad
+### Pflicht für Web-Search-Tools
 
 ```dotenv
-TAVILY_API_KEY=
+TAVILY_API_KEY=<key>
 ```
 
-`TAVILY_API_KEY` ist nur nötig, wenn im `doc_server` der Tavily-basierte Fallback
-`web_search_documentation` genutzt werden soll.
-
-Die `llms.txt`-basierten Doku-Tools funktionieren auch ohne Tavily-Key.
+`TAVILY_API_KEY` ist erforderlich für `web_search_documentation` und `web_search`.
+Die `llms.txt`-basierten Doku-Tools (`fetch_*_docs`) funktionieren auch ohne Key.
 
 ### Nicht nötig für den aktuellen Defaultpfad
 
-Diese Variablen sind aktuell **nicht** nötig, solange nur `doc_server` als Default läuft:
+Diese Variablen sind aktuell **nicht** nötig, solange nur der Default-Stack (`doc_server` + `web_search_server`) läuft:
 
 ```dotenv
 PORT_SCRAPER=8001
@@ -151,9 +151,9 @@ docker compose up -d
 
 Warum genügt das?
 
-- `doc_server` liegt in `docker-compose.override.yml`
+- `doc_server` und `web_search_server` liegen in `docker-compose.override.yml`
 - zusätzliche Services in `docker-compose.yml` laufen nur mit Profil `full-stack`
-- dadurch startet der Standardpfad nur den aktuellen `doc_server`
+- dadurch startet der Standardpfad genau diese beiden Server
 
 ---
 
@@ -169,12 +169,14 @@ docker compose ps
 
 ```zsh
 curl -fsS http://localhost:8004/health
+curl -fsS http://localhost:8006/health
 ```
 
-Erwartete Antwort:
+Erwartete Antworten:
 
 ```json
 {"status":"ok","server":"doc-server"}
+{"status":"ok","server":"web-search-server"}
 ```
 
 ### MCP-Ziel prüfen
@@ -183,8 +185,8 @@ Erwartete Antwort:
 cat .mcp.json
 ```
 
-Für den aktuellen Defaultpfad muss `doc-server` als MCP-Endpunkt enthalten sein,
-und es sollen keine weiteren Server in der kanonischen Datei stehen.
+Für den aktuellen Defaultpfad müssen `doc-server` und `web-search-server` als
+MCP-Endpunkte enthalten sein.
 
 ---
 
@@ -194,12 +196,13 @@ und es sollen keine weiteren Server in der kanonischen Datei stehen.
 
 ```zsh
 docker compose logs -f doc-server
+docker compose logs -f web-search-server
 ```
 
 ### Stoppen
 
 ```zsh
-docker compose stop doc-server
+docker compose stop
 ```
 
 ### Komplett herunterfahren

--- a/docs/runbooks/repo-cleanup.md
+++ b/docs/runbooks/repo-cleanup.md
@@ -1,0 +1,192 @@
+# Repo-Cleanup Runbook
+
+> Generisches Runbook für den sauberen Abschluss einer Arbeitsphase in einem Repo.
+> Wird am Ende jedes größeren Feature-Blocks oder Epics ausgeführt.
+> Für jedes Projekt anwendbar – Pfade und Branch-Namen anpassen.
+
+---
+
+## Wann ausführen
+
+- Nach Abschluss eines Epics oder Feature-Blocks
+- Bevor ein neuer Arbeitsbereich (z. B. Client-Seite) beginnt
+- Vor einem größeren Release oder Merge-Freeze
+
+---
+
+## 1. Offene PRs / Branches klären
+
+Alle Feature-Branches müssen entweder einen offenen PR haben oder gelöscht sein.
+
+```zsh
+# Offene Branches auf GitHub prüfen
+gh pr list --state open
+
+# Branches ohne PR identifizieren
+git branch -r | grep "feature/" | while read branch; do
+  name=$(echo $branch | sed 's/origin\///')
+  gh pr list --head "$name" --json number --jq '.[].number' 2>/dev/null | grep -q . \
+    || echo "KEIN PR: $name"
+done
+```
+
+→ Für jeden Branch ohne PR: entweder PR öffnen oder Branch löschen.
+
+---
+
+## 2. Stashes auflösen
+
+```zsh
+git stash list
+```
+
+Für jeden Stash entscheiden:
+
+| Zustand | Aktion |
+|---|---|
+| Inhalt relevant, noch nicht committed | `git stash pop` → committen |
+| Inhalt überholt / bereits in Branch enthalten | `git stash drop stash@{N}` |
+
+Kein Stash darf unkommentiert zurückbleiben.
+
+---
+
+## 3. Lokale Branches bereinigen (`gf_cleanup`)
+
+```zsh
+git checkout develop && git pull
+gf_cleanup
+```
+
+`gf_cleanup` löscht alle lokalen Branches die bereits in `develop` enthalten sind
+und führt `git remote prune origin` aus.
+
+Manuell (falls `gf_cleanup` nicht verfügbar):
+
+```zsh
+git branch --merged develop | grep -v "develop\|main" | xargs git branch -d
+git remote prune origin
+```
+
+---
+
+## 4. Alte Remote-Branches auf GitHub löschen
+
+`git remote prune origin` löscht nur dead tracking refs lokal – die Branches
+auf GitHub bleiben bestehen. Gemergte Remote-Branches manuell entfernen:
+
+```zsh
+# Gemergte Remote-Branches anzeigen
+git branch -r --merged origin/develop \
+  | grep "origin/feature/" \
+  | sed 's/origin\///' \
+  | grep -v "develop\|main"
+
+# Löschen (einzeln oder in Schleife)
+git push origin --delete feature/ISSUE-XX
+```
+
+Oder via GitHub CLI:
+
+```zsh
+gh api repos/{owner}/{repo}/branches \
+  --jq '.[].name' | grep "feature/" \
+  | while read b; do
+      gh api -X DELETE "repos/{owner}/{repo}/git/refs/heads/$b"
+    done
+```
+
+---
+
+## 5. TODOs auf Ticket-Referenzen prüfen
+
+Kein `TODO` ohne Issue-Referenz im finalen Code:
+
+```zsh
+grep -rn "TODO" servers/ shared/ tests/ src/ app/ | grep -v "# TODO #"
+```
+
+→ Jeden Treffer entweder mit `# TODO #<nr>:` ergänzen oder entfernen.
+
+---
+
+## 6. Auskommentierten Code entfernen
+
+```zsh
+grep -rn "^# .*def \|^# .*class \|^#.*import " servers/ shared/ src/ app/
+```
+
+→ Nur als Kommentar getarnte Code-Blöcke (keine erklärenden Kommentare) entfernen.
+
+---
+
+## 7. Dependency-Audit
+
+```zsh
+# Dependency-Baum prüfen
+uv tree
+
+# Konflikte und veraltete Packages
+uv sync
+
+# Nach Entfernen ungenutzter Packages: Lock-Datei aktualisieren
+uv lock
+```
+
+**Nicht verwenden:** `uv run pip check` – liefert in uv-Projekten irreführende Ergebnisse.
+
+---
+
+## 8. Docs-Konsistenz prüfen
+
+Runbooks und README müssen den aktuellen Stand widerspiegeln:
+
+```zsh
+# Schnellcheck: Default-Services, Ports, Variablen
+grep -n "8001\|8002\|8003\|8004\|8005\|8006" docs/runbooks/**/*.md README.md
+```
+
+→ Veraltete Port-Einträge, veraltete Servicelisten oder falsche Default-Markierungen korrigieren.
+
+---
+
+## 9. Abschluss-Verifikation
+
+```zsh
+uv run ruff check .
+uv run black --check .
+uv run pytest --tb=short -q
+```
+
+Alle drei müssen grün sein. Wenn nicht → Fehler beheben bevor PR geöffnet wird.
+
+---
+
+## Definition of Done
+
+```zsh
+git stash list                         # → leer
+git branch --merged develop            # → nur develop / main
+git branch -r | grep "feature/"        # → nur aktive Branches
+uv run ruff check . && uv run black --check . && uv run pytest --tb=short -q
+```
+
+Erwartung: Repo ist in einem sauberen, reviewbaren Zustand.
+
+---
+
+## Checkliste
+
+```
+[ ] Alle offenen Branches haben einen PR oder sind gelöscht
+[ ] Keine Stashes ohne Begründung
+[ ] Keine gemergten lokalen Branches
+[ ] Keine gemergten Remote-Feature-Branches auf GitHub
+[ ] Alle TODO-Kommentare haben Ticket-Referenzen
+[ ] Keine auskommentierten Code-Blöcke
+[ ] uv tree / uv sync ohne Konflikte
+[ ] uv.lock aktuell (nach Dependency-Änderungen: uv lock committen)
+[ ] README und Runbooks spiegeln aktuellen Stand wider
+[ ] ruff check + black --check + pytest grün
+```
+


### PR DESCRIPTION
Closes #44
## Changes
- `docs/runbooks/repo-cleanup.md` – generisches Cleanup-Runbook (Stashes, Remote-Branches, TODOs, Dependency-Audit, DoD-Checkliste)
- `docs/runbooks/mcp/default-setup.md` – auf aktuellen Stand gebracht: `doc-server` + `web-search-server` als Default, Verifikation für beide Server, Logs/Stop aktualisiert
- Staler Stash (WIP ISSUE-41) gedroppt
- Remote Feature-Branches via `git fetch --prune` bereinigt